### PR TITLE
Enhance search filter functionality

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,9 +10,17 @@ import { NgxPaginationModule } from 'ngx-pagination';
 import { PokeApiService } from './services/poke-api.service';
 import { Ng2SearchPipeModule } from 'ng2-search-filter';
 import { FormsModule } from '@angular/forms';
+import { CardComponent } from './components/card/card.component';
+import { SpriteComponent } from './components/sprite/sprite.component';
 
 @NgModule({
-  declarations: [AppComponent, PokeNavComponent, DexGridComponent],
+  declarations: [
+    AppComponent,
+    PokeNavComponent,
+    DexGridComponent,
+    CardComponent,
+    SpriteComponent
+  ],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -1,0 +1,37 @@
+<div class="box">
+  <div class="default">
+    <svg
+      class="{{ details.types[0].type.name }}"
+      viewBox="0 0 500 500"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <ellipse
+        *ngIf="details.types.length > 1"
+        class="{{ details.types[1].type.name }}"
+        cx="250"
+        cy="250"
+        rx="200"
+        ry="200"
+      />
+      <ellipse
+        *ngIf="details.types.length == 1"
+        class="{{ details.types[0].type.name }}"
+        cx="250"
+        cy="250"
+        rx="200"
+        ry="200"
+      />
+    </svg>
+
+    <app-sprite [sprite]="displaySprite" ></app-sprite>
+
+    <h5 class="poke-name">{{ details.name }}</h5>
+    <p class="poke-id">{{ details.id }}</p>
+    <p class="poke-types">
+      <span>{{ details.types[0].type.name }}</span>
+      <span *ngIf="details.types.length > 1">
+        / {{ details.types[1].type.name }}</span
+      >
+    </p>
+  </div>
+</div>

--- a/src/app/components/card/card.component.scss
+++ b/src/app/components/card/card.component.scss
@@ -1,0 +1,55 @@
+.box {
+  max-width: 200px;
+  min-width: 200px;
+  height: auto;
+  margin-top: 5px;
+  padding: 5px;
+  border: solid 1px black;
+  border-radius: 5%;
+  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #212a39;
+  color: #fff;
+  text-shadow: 2px 2px black;
+  text-transform: capitalize;
+  text-align: center;
+  font-size: 12px;
+
+  .poke-id {
+    font-size: 12px;
+    margin-bottom: 0.5rem;
+  }
+
+  .poke-name {
+    font-size: 16px;
+  }
+
+  .default {
+    position: relative;
+    width: 100%;
+    svg {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: auto;
+
+      ellipse {
+        fill: rgba(216, 216, 216, 0);
+        stroke-width: 20px;
+        filter: blur(22px);
+      }
+
+    }
+    img {
+      width: 100%;
+      margin: auto;
+    }
+  }
+
+  span {
+    font-size: 12px;
+  }
+}

--- a/src/app/components/card/card.component.spec.ts
+++ b/src/app/components/card/card.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardComponent } from './card.component';
+
+describe('CardComponent', () => {
+  let component: CardComponent;
+  let fixture: ComponentFixture<CardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CardComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/card/card.component.ts
+++ b/src/app/components/card/card.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { PokeApiService } from 'src/app/services/poke-api.service';
+
+@Component({
+  selector: 'app-card',
+  templateUrl: './card.component.html',
+  styleUrls: ['./card.component.scss']
+})
+export class CardComponent implements OnInit {
+  @Input() item!: any
+  details: any
+  displaySprite: any
+
+  constructor(private pokeApi: PokeApiService) { }
+
+  ngOnInit(): void {
+    this.pokeApi
+      .getPokemonDetails(this.item.name)
+      .subscribe((data: any) => {
+        this.details = data
+        this.calculateDisplaySprite()
+      });
+  }
+
+  calculateDisplaySprite() {
+    if(this.details.sprites.front_default != null) {
+      this.displaySprite = this.details.sprites.front_default
+    }
+
+    if(this.details.sprites.front_default == null) {
+      this.displaySprite = this.details.sprites.other.home.front_default
+    }
+
+    if(this.details.sprites.front_default != null && this.details.sprites.other.home.front_default == null) {
+      this.displaySprite = this.details.sprites.other['official-artwork'].front_default
+    }
+
+    if(this.details.id == 10181) {
+      this.displaySprite = this.details.sprites.versions['generation-vii']['ultra-sun-ultra-moon'].front_default
+    }
+
+    if(this.details.id == 10158 || this.details.id == 10159) {
+      this.displaySprite = this.details.sprites.versions['generation-viii'].icons.front_default
+    }
+  }
+}

--- a/src/app/components/dex-grid/dex-grid.component.html
+++ b/src/app/components/dex-grid/dex-grid.component.html
@@ -5,87 +5,14 @@
     placeholder="Search Here"
     name="term"
     [(ngModel)]="term"
-
   />
 </div>
 
 <div class="card-grid">
-  <div
-    class="box"
-    *ngFor="
-      let item of pokemon | filter: term
-        | paginate
-          : { itemsPerPage: limit, currentPage: page, totalItems: totalNumber }
-    "
-  >
-    <div class="default">
-      <svg
-        class="{{ item.types[0].type.name }}"
-        viewBox="0 0 500 500"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <ellipse
-          *ngIf="item.types.length > 1"
-          class="{{ item.types[1].type.name }}"
-          cx="250"
-          cy="250"
-          rx="200"
-          ry="200"
-        />
-        <ellipse
-          *ngIf="item.types.length == 1"
-          class="{{ item.types[0].type.name }}"
-          cx="250"
-          cy="250"
-          rx="200"
-          ry="200"
-        />
-      </svg>
-      <div class="default">
-        <img
-          *ngIf="item.sprites.front_default != null"
-          src="{{ item.sprites.front_default }}"
-        />
-        <img
-          *ngIf="item.sprites.front_default == null"
-          src="{{ item.sprites.other.home.front_default }}"
-        />
-        <img
-          *ngIf="
-            item.sprites.front_default == null &&
-            item.sprites.other.home.front_default == null
-          "
-          src="{{ item.sprites.other['official-artwork'].front_default }}"
-        />
-
-        <img
-          *ngIf="item.id == 10181"
-          src="{{
-            item.sprites.versions['generation-vii']['ultra-sun-ultra-moon']
-              .front_default
-          }}"
-        />
-
-        <img
-          *ngIf="item.id == 10158 || item.id == 10159"
-          src="{{
-            item.sprites.versions['generation-viii'].icons.front_default
-          }}"
-        />
-      </div>
-
-      <h5 class="poke-name">{{ item.name }}</h5>
-      <p class="poke-id">{{ item.id }}</p>
-      <p class="poke-types">
-        <span>{{ item.types[0].type.name }}</span>
-        <span *ngIf="item.types.length > 1">
-          / {{ item.types[1].type.name }}</span
-        >
-      </p>
-    </div>
-  </div>
+  <app-card
+    *ngFor="let item of pokemon | filter: term | paginate: { itemsPerPage: limit, currentPage: page }"
+    [item]="item"
+  ></app-card>
 </div>
-<pagination-controls
-  class="poke-paginate"
-  (pageChange)="page = $event; pokemon = []; getData()"
-></pagination-controls>
+
+<pagination-controls class="poke-paginate" (pageChange)="pageChange($event);"></pagination-controls>

--- a/src/app/components/dex-grid/dex-grid.component.scss
+++ b/src/app/components/dex-grid/dex-grid.component.scss
@@ -13,62 +13,6 @@
   gap: 0.5em;
   width: min(100% - 5rem);
   margin-inline: auto;
-
-  .box {
-    max-width: 200px;
-    min-width: 200px;
-    height: auto;
-    margin-top: 5px;
-    padding: 5px;
-    border: solid 1px black;
-    border-radius: 5%;
-    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.3);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    background-color: #212a39;
-    color: #fff;
-    text-shadow: 2px 2px black;
-    text-transform: capitalize;
-    text-align: center;
-    font-size: 12px;
-
-    .poke-id {
-      font-size: 12px;
-      margin-bottom: 0.5rem;
-    }
-
-    .poke-name {
-      font-size: 16px;
-    }
-
-    .default {
-      position: relative;
-      width: 100%;
-      svg {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
-        height: auto;
-
-        ellipse {
-          fill: rgba(216, 216, 216, 0); 
-          stroke-width: 20px;
-          filter: blur(22px);
-        }
-
-      }
-      img {
-        width: 100%;
-        margin: auto;
-      }
-    }
-
-    span {
-      font-size: 12px;
-    }
-  }
 }
 
 .poke-paginate ::ng-deep {

--- a/src/app/components/dex-grid/dex-grid.component.ts
+++ b/src/app/components/dex-grid/dex-grid.component.ts
@@ -9,62 +9,26 @@ import { PokeApiService } from 'src/app/services/poke-api.service';
 
 export class DexGridComponent implements OnInit {
   title = 'Pokedex';
-  pokeData: any;
   pokemon: any = [];
   page: number = 1;
   totalNumber: any;
   limit: number = 10;
   term: any;
 
-  constructor(private apiCall: PokeApiService) {}
+  constructor(private pokeApi: PokeApiService) {}
 
   ngOnInit() {
     this.getData();
   }
 
   getData() {
-    this.apiCall
-      .getData(this.limit, this.page * this.limit - this.limit)
-      .subscribe((data: any) => {
-        console.log(data);
-        this.totalNumber = data.count;
-
-        data.results.forEach((result: any) => {
-          this.apiCall.getMoreData(result.name).subscribe((data: any) => {
-            this.pokemon.push(data);
-            // this.pokeData = data;
-            // console.log(this.pokeData);
-
-            this.pokemon.sort((a: any, b: any) => a.id - b.id);
-            // console.log(this.pokemon);
-          });
-        });
-      });
+    this.pokeApi.getPokemon(1123,0).subscribe((res) => {
+      this.totalNumber = res.count;
+      this.pokemon = res.results
+    })
   }
 
-  // searchPokemon() {
-  //   if(this.term === ""){
-  //     this.ngOnInit();
-  //   }else {
-  //     this.apiCall
-  //     .getData(25, 0)
-  //     .subscribe((data: any) => {
-  //       this.totalNumber = data.count;
-
-  //       data.results.forEach((result: any) => {
-  //         this.apiCall.getMoreData(result.name).subscribe((data: any) => {
-  //           this.pokemon.push(data);
-  //           // console.log(this.pokemon);
-  //           this.pokemon.filter((res: any) => {
-  //             return res.name.toLocaleLowerCase().match(this.term.toLocaleLowerCase());
-  //           })
-  //         });
-
-  //         });
-  //       });
-  //     }
-  //   }
+  pageChange(input: any) {
+    this.page = input;
   }
-
-
-
+}

--- a/src/app/components/sprite/sprite.component.html
+++ b/src/app/components/sprite/sprite.component.html
@@ -1,0 +1,3 @@
+<div class="default">
+  <img src="{{ sprite }}"/>
+</div>

--- a/src/app/components/sprite/sprite.component.spec.ts
+++ b/src/app/components/sprite/sprite.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SpriteComponent } from './sprite.component';
+
+describe('SpriteComponent', () => {
+  let component: SpriteComponent;
+  let fixture: ComponentFixture<SpriteComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SpriteComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SpriteComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/sprite/sprite.component.ts
+++ b/src/app/components/sprite/sprite.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-sprite',
+  templateUrl: './sprite.component.html',
+  styleUrls: ['./sprite.component.scss']
+})
+export class SpriteComponent implements OnInit {
+  @Input() sprite: any
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+}

--- a/src/app/services/poke-api.service.ts
+++ b/src/app/services/poke-api.service.ts
@@ -10,12 +10,11 @@ export class PokeApiService {
   constructor(private http: HttpClient) {}
   url = 'https://pokeapi.co/api/v2/pokemon';
 
-  getData(limit: number, offset: number): Observable<any> {
-    console.log(this.url + '?limit=' + limit + '&offset=' + offset);
+  getPokemon(limit: number, offset: number): Observable<any> {
     return this.http.get(this.url + '?limit=' + limit + '&offset=' + offset);
   }
 
-  getMoreData(name: string) {
+  getPokemonDetails(name: string) {
     return this.http.get(this.url + '/' + name);
   }
 }


### PR DESCRIPTION
- Because the API dose not have search functionality I have obtained the initial list of Pokémon (without their details) and stored this in-memory. This allows you to filter the list when using a search term.
- I've extracted the html for the card from the dex-grid so that we can handle getting the details within the card component
- I've also refactored the image display so that single image tag can be used. The logic for calculating which image is needed has been moved to the .ts file.